### PR TITLE
Improve version logic

### DIFF
--- a/src/songs/song.entity.ts
+++ b/src/songs/song.entity.ts
@@ -35,6 +35,9 @@ export class Song {
   @ManyToOne(() => Artist, (artist) => artist.songs, { onDelete: 'CASCADE' })
   artist: Artist;
 
+  @Column()
+  artistId: string;
+
   @OneToMany(() => Version, (version) => version.song)
   versions: Version[];
 }

--- a/src/songs/songs.module.ts
+++ b/src/songs/songs.module.ts
@@ -5,9 +5,14 @@ import { AuthModule } from '../auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Song } from './song.entity';
 import { Artist } from '../artists/artist.entity';
+import { VersionsModule } from 'src/versions/versions.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Song, Artist]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([Song, Artist]),
+    AuthModule,
+    VersionsModule,
+  ],
   controllers: [SongsController],
   providers: [SongsService],
 })

--- a/src/versions/version.entity.ts
+++ b/src/versions/version.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  Index,
   ManyToOne,
   PrimaryGeneratedColumn,
   OneToMany,
@@ -11,6 +12,7 @@ import { Song } from '../songs/song.entity';
 import { Note } from '../notes/note.entity';
 
 @Entity()
+@Index(['number', 'song'], { unique: true })
 export class Version {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/versions/versions.module.ts
+++ b/src/versions/versions.module.ts
@@ -11,5 +11,6 @@ import { VersionsSubscriber } from '../subscriber/versions.subscriber';
   imports: [TypeOrmModule.forFeature([Version, Song]), AuthModule],
   controllers: [VersionsController],
   providers: [VersionsService, VersionsSubscriber],
+  exports: [VersionsService],
 })
 export class VersionsModule {}

--- a/src/versions/versions.service.ts
+++ b/src/versions/versions.service.ts
@@ -6,28 +6,28 @@ import {
 import { CreateVersionDto } from './dtos/create-version.dto';
 import { Version } from './version.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Song } from '../songs/song.entity';
+// import { Song } from '../songs/song.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
 export class VersionsService {
   constructor(
-    @InjectRepository(Song)
-    private songsRepository: Repository<Song>,
+    // @InjectRepository(Song)
+    // private songsRepository: Repository<Song>,
     @InjectRepository(Version)
     private versionsRepository: Repository<Version>,
   ) {}
 
   async createVersion(createVersionDto: CreateVersionDto): Promise<Version> {
-    const alreadyExists = createVersionDto.song.versions.filter(
-      (version) => version.number === createVersionDto.number,
-    );
+    // const alreadyExists = createVersionDto.song.versions.filter(
+    //   (version) => version.number === createVersionDto.number,
+    // );
 
-    if (alreadyExists.length > 0) {
-      throw new ConflictException(
-        `${createVersionDto.song.title} already has a Mix Version # ${createVersionDto.number}`,
-      );
-    }
+    // if (alreadyExists.length > 0) {
+    //   throw new ConflictException(
+    //     `${createVersionDto.song.title} already has a Mix Version # ${createVersionDto.number}`,
+    //   );
+    // }
 
     const version = this.versionsRepository.create({
       number: createVersionDto.number,
@@ -36,7 +36,15 @@ export class VersionsService {
 
     try {
       return await this.versionsRepository.save(version);
-    } catch (error) {}
+    } catch (error) {
+      if (error.code === '23505') {
+        throw new ConflictException(
+          `${createVersionDto.song.title} already has a version number ${createVersionDto.number}`,
+        );
+      } else {
+        return error;
+      }
+    }
   }
 
   async updateVersion(


### PR DESCRIPTION
adds @Index to Version Entity to prevent duplicate versioning for each song,
removes unused injection of song repository in version service,
removes unnecessary filter for duplicate version number in versions service createVersion,
moves Conflict Exception into catch,
adds VersionsService export in VersionsModule,
adds VersionsModule import to SongsModule,
adds private readonly versionsService to SongsService constructor,
adds logic to create a Version 1 when creating a new song,
adds artistId to Song Entity